### PR TITLE
Update Linux kernel to 6.12 and Debian distribution to Bookworm

### DIFF
--- a/.env
+++ b/.env
@@ -2,11 +2,11 @@
 ################################################################################
 # For the following two check scripts/min-tool-version.sh of your kernel
 # Rust toolchain version
-RUST_VERSION=1.62.0
+RUST_VERSION=1.78.0
 # Bindgen version
-BINDGEN_VERSION=0.56.0
+BINDGEN_VERSION=0.65.1
 
-KERNEL_SOURCE_URL=https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.4.3.tar.xz
+KERNEL_SOURCE_URL=https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.tar.xz
 KERNEL_ARCHIVE_NAME=$(echo ${KERNEL_SOURCE_URL} | rev | cut -d '/' -f 1 | rev)
 KERNEL_BUILD_JOBS=4
 
@@ -32,7 +32,7 @@ RKB_UBUNTU_VERSION=22.04
 RKB_UNAME="${DUNAME}"
 RKB_UID=${DUID}
 RKB_GID=${DGID}
-RKB_WORKDIR="/home/${RKB_UNAME}/workspace"
+RKB_WORKDIR="${PWD}"
 RKB_DOCKER_RUN_ADD_OPT=""
 
 ################################################################################
@@ -45,10 +45,10 @@ RFS_UBUNTU_VERSION=22.04
 RFS_UNAME="${DUNAME}"
 RFS_UID=1000
 RFS_GID=1000
-RFS_WORKDIR="/home/${RFS_UNAME}/workspace"
+RFS_WORKDIR="${PWD}"
 RFS_DOCKER_RUN_ADD_OPT="${DOCKER_RUN_ADD_OPT}"
 # https://www.debian.org/releases
-RFS_DISTRIBUTION=bullseye
+RFS_DISTRIBUTION=bookworm
 RFS_PACKAGES=build-essential,vim,openssh-server,make,sudo,curl,tar,gcc,libc6-dev,time,strace,less,psmisc,selinux-utils,policycoreutils,checkpolicy,selinux-policy-default,firmware-atheros,openssl,plymouth,file
 RFS_HOSTNAME=RoustKit
 RFS_ARCH=x86_64
@@ -72,7 +72,7 @@ RKE_UBUNTU_VERSION=22.04
 RKE_UNAME="${DUNAME}"
 RKE_UID=${RFS_UID}
 RKE_GID=${RFS_GID}
-RKE_WORKDIR="/home/${RKE_UNAME}/workspace"
+RKE_WORKDIR="${PWD}"
 # Port mapping must patch the configuration in RKE_QEMU_NET
 RKE_DOCKER_RUN_ADD_OPT="${DOCKER_RUN_ADD_OPT} -p 10021:10021"
 RKE_QEMU_SMP=1

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ TODOs
 src/*.mod*
 src/.*.ko*
 src/.*.o*
+src/.Module.symvers*
 src/Module.symvers
 src/modules.order
 kernel/linux

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ insmod /tmp/src/rust_oot.ko
 - verify that the module has been correctly loaded:
 
 ```
-dmes | grep rust_oot
+dmesg | grep rust_oot
 ...
 [   72.263075] rust_oot: loading out-of-tree module taints kernel.
 [   72.267374] rust_oot: Rust OOT sample (init)
@@ -340,7 +340,7 @@ default is placed in directory `rootfs` with name
 
 ```bash
 ls ./rootfs
-bullseye-x86_64-ext4
+bookworm-x86_64-ext4
 ```
 
 Also, by default there are two users configured in the created filesystems:

--- a/docker/rkbuilder/Dockerfile
+++ b/docker/rkbuilder/Dockerfile
@@ -39,7 +39,7 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain ${RUST_VERSION} -y
 ENV PATH="/home/${UNAME}/.cargo/bin:${PATH}"
 RUN rustup component add rust-src && \
-    cargo install --locked --version ${BINDGEN_VERSION} bindgen && \
+    cargo install --locked --version ${BINDGEN_VERSION} bindgen-cli && \
     rustup component add rustfmt && \
     rustup component add clippy
 

--- a/docker/rootfs/rootfs.sh
+++ b/docker/rootfs/rootfs.sh
@@ -10,7 +10,7 @@ MNT_BASE=/rootfs
 SEEK=3071
 PKGS="build-essential,openssh-server,sudo,curl,tar,time,less,psmisc,openssl,plymouth,file"
 ARCH=$(uname -m)
-DIST=bullseye
+DIST=bookworm
 ROOTFS_DST_DIR="/rootfs"
 ROOTFS_NAME=rootfs
 USER=user
@@ -25,7 +25,7 @@ while (("$#")); do
 		shift 2
 		;;
 	-d | --distribution)
-		# Sets the debian distribution, which defaults to bullseye right now
+		# Sets the debian distribution, which defaults to bookworm right now
 		DIST=$2
 		shift 2
 		;;
@@ -155,7 +155,7 @@ sudo rm -rf $MNT >/dev/null
 sudo mkdir -p $MNT >/dev/null
 sudo chmod 0755 $MNT >/dev/null
 
-DEBOOTSTRAP_PARAMS="--arch=$DEBARCH --include=$PKGS --components=main,contrib,non-free $DIST $MNT"
+DEBOOTSTRAP_PARAMS="--arch=$DEBARCH --include=$PKGS --components=main,contrib,non-free-firmware $DIST $MNT"
 if [ $FOREIGN = "true" ]; then
 	DEBOOTSTRAP_PARAMS="--foreign $DEBOOTSTRAP_PARAMS"
 fi

--- a/src/rust_oot.rs
+++ b/src/rust_oot.rs
@@ -18,9 +18,9 @@ impl kernel::Module for RustOot {
         pr_info!("Rust OOT sample (init)\n");
 
         let mut numbers = Vec::new();
-        numbers.try_push(72)?;
-        numbers.try_push(108)?;
-        numbers.try_push(200)?;
+        numbers.push(72, GFP_KERNEL)?;
+        numbers.push(108, GFP_KERNEL)?;
+        numbers.push(200, GFP_KERNEL)?;
 
         Ok(RustOot { numbers })
     }


### PR DESCRIPTION
Hi, 

Thank you for your great work! I started using your development kit for some student work. Therefore, I updated the used kernel to the latest version (6.12) and switched from Debian Bullseye to Debian Bookworm, which required a few changes in your scripts. 

Maybe you would like to use this PR to update the repository :)

